### PR TITLE
RFC: Improve mocks handling, builtIn modules and more.

### DIFF
--- a/package/plugin/codemods/jest-mock/extract_mocked_specifier.test.js
+++ b/package/plugin/codemods/jest-mock/extract_mocked_specifier.test.js
@@ -28,7 +28,7 @@ function expectCodemod(code, codemod, expectedOutput) {
   });
 
   const output = multilineTrim(babelGenerate(ast).code);
-
+  console.log(output);
   expect(output).toBe(multilineTrim(expectedOutput));
 }
 
@@ -40,7 +40,7 @@ describe("codemods/jest-mock/extract_mocked_specifier", () => {
         a: 'a'
       }));
       `,
-      (path) => extract_mocked_specifier(path, "a"),
+      (path) => extract_mocked_specifier(path, "a", { name: "a" }),
       `
       jest.mock('./origin.js', () => ({
         a: 'a'
@@ -57,7 +57,7 @@ describe("codemods/jest-mock/extract_mocked_specifier", () => {
         b: 'b'
       }));
       `,
-      (path) => extract_mocked_specifier(path, "b"),
+      (path) => extract_mocked_specifier(path, "b", { name: "b" }),
       `
       jest.mock('./origin.js', () => ({
         b: 'b'
@@ -79,8 +79,8 @@ describe("codemods/jest-mock/extract_mocked_specifier", () => {
       }));
       `,
       (path) => {
-        extract_mocked_specifier(path, "b");
-        extract_mocked_specifier(path, "c");
+        extract_mocked_specifier(path, "b", { name: "b" });
+        extract_mocked_specifier(path, "c", { name: "c" });
       },
       `
       jest.mock('./origin.js', () => ({

--- a/package/plugin/index.js
+++ b/package/plugin/index.js
@@ -317,9 +317,7 @@ module.exports = function babelPlugin(babel) {
               if (path.node.specifiers.length > 1) {
               
                 const newImport = getNewImport(specifierOrigin, specifier);
-                // if(state.file.opts.filename.includes('ShopifyRegister')) {
-                //   console.log(state.opts.filename, specifierOrigin, specifier, newImport)
-                // }
+               
                 path.insertBefore([newImport]);
                 toRemove.push(index);
               }

--- a/package/plugin/trace/trace_export_named_declaration.js
+++ b/package/plugin/trace/trace_export_named_declaration.js
@@ -53,7 +53,7 @@ function trace_export_named_declaration(
               } else if (expSpecifier.type === "ExportNamespaceSpecifier") {
                 // export * as specifier from './original';
                 state.match = {
-                  name: "*",
+                  name: '*',
                   source,
                   file: codeFilePath,
                 };

--- a/package/plugin/utils.js
+++ b/package/plugin/utils.js
@@ -1,4 +1,13 @@
 const babelParser = require("@babel/parser");
+const { builtinModules } = require("module");
+const babelTypes = require("@babel/types");
+
+function isBuiltInModule(moduleName) {
+  return (
+    builtinModules.includes(moduleName) ||
+    ["canvas", "crypto"].includes(moduleName)
+  );
+}
 
 function matchAnyRegex(regexArray, haystack) {
   for (let i = 0; i < regexArray.length; i++) {
@@ -24,8 +33,31 @@ function babelParse(code) {
   return babelParser.parse(code, parserConfig);
 }
 
+function getNewImport(specifierOrigin, specifier) {
+  return specifierOrigin.name !== "*"
+    ? babelTypes.importDeclaration(
+        [
+          babelTypes.importSpecifier(
+            babelTypes.identifier(specifier.local.name),
+            babelTypes.identifier(specifierOrigin.name),
+          ),
+        ],
+        babelTypes.stringLiteral(specifierOrigin.source),
+      )
+    : babelTypes.importDeclaration(
+        [
+          babelTypes.importNamespaceSpecifier(
+            babelTypes.identifier(specifier.local.name),
+          ),
+        ],
+        babelTypes.stringLiteral(specifierOrigin.source),
+      );
+}
+
 module.exports = {
   matchAnyRegex,
   removeItemsByIndexesInPlace,
   babelParse,
+  isBuiltInModule,
+  getNewImport,
 };

--- a/spec/jest-mock-rewrites.spec.js
+++ b/spec/jest-mock-rewrites.spec.js
@@ -1,61 +1,58 @@
 const {
-  createExpectTransform,
   createExpectJestTransform,
 } = require("./test-utils/expectTransform.js");
 
 const expectJestTransform = createExpectJestTransform(__filename);
-const expectTransform = createExpectTransform(__filename);
 
 describe("babel-jest-boost plugin jest.mock rewrites", () => {
-  it("resolves modules mocked in jest.mock", () => {
-    expectTransform(
+  it.each([
+    [
       "import { a } from './test_tree/consts'",
       `import { a } from "${__dirname}/test_tree/consts/a.js";`,
-    );
-    expectJestTransform(
+    ],
+    [
       "jest.mock('./test_tree/default');",
       `_getJestObj().mock("${__dirname}/test_tree/default/index.js");`,
-    );
-
-    expectJestTransform(
+    ],
+    [
       "jest.mock('./test_tree/default', () => {});",
       `_getJestObj().mock("${__dirname}/test_tree/default/index.js", () => {});`,
-    );
-
-    expectJestTransform(
+    ],
+    [
       `jest.mock('./test_tree/consts', () => ({ a: 1 }));`,
       `
-        _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
-          a: 1
-        }));
-      `,
-    );
-    expectJestTransform(
+          _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
+            a: 1
+          }));
+        `,
+    ],
+    [
       `jest.mock('./test_tree/consts', () => ({ a: 1, b: 2 }));`,
       `
-        _getJestObj().mock("${__dirname}/test_tree/consts/b.js", () => ({
-          b: 2
-        }));
-        _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
-          a: 1
-        }));
-      `,
-    );
-
-    expectJestTransform(
+            _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
+              a: 1
+            }));
+            _getJestObj().mock("${__dirname}/test_tree/consts/b.js", () => ({
+              b: 2
+            }));
+          `,
+    ],
+    [
       `jest.mock("${__dirname}/test_tree/consts/consts.js", () => ({ a: 1, b: 2, c: 3, d: 4 }));`,
       `
-        _getJestObj().mock("${__dirname}/test_tree/consts/consts.js", () => ({
-          c: 3,
-          d: 4
-        }));
-        _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
-          a: 1
-        }));
-        _getJestObj().mock("${__dirname}/test_tree/consts/b.js", () => ({
-          b: 2
-        }));
-      `,
-    );
+              _getJestObj().mock("${__dirname}/test_tree/consts/consts.js", () => ({
+                c: 3,
+                d: 4
+              }));
+              _getJestObj().mock("${__dirname}/test_tree/consts/a.js", () => ({
+                a: 1
+              }));
+              _getJestObj().mock("${__dirname}/test_tree/consts/b.js", () => ({
+                b: 2
+              }));
+            `,
+    ],
+  ])("resolves modules mocked in jest.mock", (input, output) => {
+    expectJestTransform(input, output);
   });
 });


### PR DESCRIPTION
Hi! First of all I want to thank you for this package. We have a pretty hefty code base with barrel imports. 650+ test suites and 3600+ tests. By making some changes to your packages to handle our code base I was able to cut testing time from from ~15 minutes to ~3 minutes on our local runs. I saw some good impact on the CI runs too but I still need to make improvements (~20 minutes to ~11 minutes).

This PR is not perfect but I wanted to get some inputs before putting more work into it. As of now we are using `patch-package` to make it so our test suite works with your package.

here's a list of things I am trying to support:

- Support wild card import by having the new import named as the old one (from `import * as * from './abc'` to `import * as abc from './abc'`
- Add check for builtIn modules to skip transform of import inspired by https://github.com/FogelAI/babel-plugin-transform-barrels
- Allow skipping node modules entirely
- Improve mock path replacement to match transformed imports correctly